### PR TITLE
Wrap Player.prototype.options

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "karma-safari-launcher": "^0.1.1",
     "mocha": "2.x.x",
     "qunitjs": "^1.19.0",
-    "video.js": "^5.0.0-rc.90"
+    "video.js": "^5.2.1"
   },
   "repository": {
     "type": "git",

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -74,7 +74,7 @@
     if (Object.prototype.toString.call(options.children) === '[object Array]') {
       for (var i = 0; i < options.children.length; i++) {
         var childName = options.children[i];
-        options.children[childName] = this.getChild(childName);
+        options.children[childName] = this.getChild(childName).options_;
       }
     }
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -3,7 +3,7 @@
     Component = videojs.getComponent('Component'),
     keys = Object.keys(videojs.browser),
     components = Object.keys(Component.components_),
-    i, key, component,
+    oldOptions, i, key, component,
 
     // Some classes changed between video.js 4 and 5. This back-fills those
     // to restore the old classes for styling or scripting purposes.
@@ -67,6 +67,19 @@
       };
     });
   });
+
+  oldOptions = videojs.Player.prototype.options;
+  videojs.Player.prototype.options = function() {
+    var options = oldOptions.call(this);
+    if (Object.prototype.toString.call(options.children) === '[object Array]') {
+      for (var i = 0; i < options.children.length; i++) {
+        var childName = options.children[i];
+        options.children[childName] = this.getChild(childName);
+      }
+    }
+
+    return options;
+  };
 
   videojs.round = function(x, y) {
     videojs.log.warn('videojs.round(x, y) is deprecated. ' +


### PR DESCRIPTION
This is necessary because some users relied on the behavior of
options().children to be an object that returned the associated object
but in 5.0 it is now an array for the default components, such as the
player. So, we want to wrap the function to attach the properies of the
children to the children array so both would be available.
This is a copy of https://github.com/forbesjo/videojs-4-5-compatibility/pull/2
