### PR TITLE
Restore vjs.createEl()

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -163,5 +163,32 @@
     }
   };
 
+  videojs.createEl = function(tagName, properties) {
+    var el;
+
+    tagName = tagName || 'div';
+    properties = properties || {};
+
+    el = document.createElement(tagName);
+
+    videojs.obj.each(properties, function(propName, val) {
+      // Not remembering why we were checking for dash
+      // but using setAttribute means you have to use getAttribute
+
+      // The check for dash checks for the aria-* attributes, like aria-label, aria-valuemin.
+      // The additional check for "role" is because the default method for adding attributes does not
+      // add the attribute "role". My guess is because it's not a valid attribute in some namespaces, although
+      // browsers handle the attribute just fine. The W3C allows for aria-* attributes to be used in pre-HTML5 docs.
+      // http://www.w3.org/TR/wai-aria-primer/#ariahtml. Using setAttribute gets around this problem.
+      if (propName.indexOf('aria-') !== -1 || propName === 'role') {
+        el.setAttribute(propName, val);
+      } else {
+        el[propName] = val;
+      }
+    });
+
+    return el;
+  };
+
   window.vjs = videojs;
 })(window, window.videojs);

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -125,7 +125,6 @@
   });
 
   // Restore missing/previously deprecated objects and methods.
-  window.vjs = videojs;
   videojs.JSON = JSON;
   videojs.USER_AGENT = window.navigator.userAgent;
   videojs.EventEmitter = videojs.EventTarget;
@@ -157,4 +156,5 @@
     isArray: Array.isArray
   };
 
+  window.vjs = videojs;
 })(window, window.videojs);

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -153,7 +153,14 @@
   };
 
   videojs.obj = {
-    isArray: Array.isArray
+    isArray: Array.isArray,
+    each: function(obj, fn, context) {
+      for (var key in obj) {
+        if (Object.prototype.hasOwnProperty.call(obj, key)) {
+          fn.call(context || this, key, obj[key]);
+        }
+      }
+    }
   };
 
   window.vjs = videojs;


### PR DESCRIPTION
This PR restores `vjs.createEl()` for compatibility. This is a copy/paste from the latest 4.0 release.
