### PR TITLE
Shimmy

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,4 +1,20 @@
 (function(window, videojs) {
+  var version;
+
+  try {
+    version = Number(videojs.VERSION.match(/\d+/)[0]);
+  } catch (x) {
+    version = null;
+  }
+
+  // Do not shim older versions or globals that have already been shimmed.
+  if (version < 5 || videojs.has4to5_) {
+    return;
+  }
+
+  // Add the shim flag.
+  videojs.has4to5_ = true;
+
   var Component = videojs.getComponent('Component');
   var Player = videojs.getComponent('Player');
 


### PR DESCRIPTION
This PR makes the "plugin" a bit more of a shim. It was never really a plugin to begin with.

Also, it applies a bit of logic to the initialization of the 4to5 shim to prevent it from being applied to video.js 4.x and from being applied more than once.
