### PR TITLE
check if polyfilledTechKeys_ exists before running loop

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -197,11 +197,12 @@
 
     originals.Player.unloadTech_.apply(player, arguments);
 
-    player.polyfilledTechKeys_.forEach(function(key) {
-      delete player.tech[key];
-    });
-
-    delete player.polyfilledTechKeys_;
+    if (player.polyfilledTechKeys_) {
+      player.polyfilledTechKeys_.forEach(function(key) {
+        delete player.tech[key];
+      });
+      delete player.polyfilledTechKeys_;
+    }
   };
 
 })(window, window.videojs);


### PR DESCRIPTION
I have experienced a scenario playing .flv videos where unloadTech_() is called before loadTech_() and so player.polyfilledTechKeys_ has not been defined yet.

I have added a variable check before running the forEach loop.
